### PR TITLE
Fix build environment

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,5 +4,7 @@ ignore =
     E501,
     # line break before binary operator
     W503,
+    # line break after binary operator
+    W504,
     # undefined name, let pylint handle this
     F821

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # python files
 __pycache__/
 *.pyc
+.venv/
 
 # pyinstaller files
 dist/

--- a/dploy/cli.py
+++ b/dploy/cli.py
@@ -7,6 +7,7 @@ import argparse
 from dploy import linkcmd
 from dploy import stowcmd
 from dploy import version
+from dploy.error import DployError
 
 
 def add_ignore_argument(parser):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pathlib>=1.0.1 # only required for python versions <3.4
+pathlib>=1.0.1; python_version < '3.4'
 # development
 invoke>=0.13.0
 virtualenv>=15.0.3


### PR DESCRIPTION
I tried to `pip install -r requirements.txt` and it blew up, so I decided to fix it.

While I looked at the code I also noticed a useless flake8 warning and a missing import.