### PR TITLE
Restore invalid dir permissions for test dirs

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,8 @@ def source_a(tmpdir):
         },
     ]
     utils.create_tree(tree)
-    return name
+    yield name
+    utils.restore_tree_permissions(tmpdir)
 
 
 @pytest.fixture()
@@ -59,7 +60,8 @@ def source_b(tmpdir):
         },
     ]
     utils.create_tree(tree)
-    return name
+    yield name
+    utils.restore_tree_permissions(tmpdir)
 
 
 @pytest.fixture()
@@ -87,7 +89,8 @@ def source_d(tmpdir):
         },
     ]
     utils.create_tree(tree)
-    return name
+    yield name
+    utils.restore_tree_permissions(tmpdir)
 
 
 @pytest.fixture()
@@ -115,7 +118,8 @@ def source_c(tmpdir):
         },
     ]
     utils.create_tree(tree)
-    return name
+    yield name
+    utils.restore_tree_permissions(tmpdir)
 
 
 @pytest.fixture()
@@ -132,7 +136,8 @@ def source_only_files(tmpdir):
         }
     ]
     utils.create_tree(tree)
-    return name
+    yield name
+    utils.restore_tree_permissions(tmpdir)
 
 
 @pytest.fixture()
@@ -142,7 +147,8 @@ def dest(tmpdir):
     """
     name = str(tmpdir.join("dest"))
     utils.create_directory(name)
-    return name
+    yield name
+    utils.restore_tree_permissions(tmpdir)
 
 
 @pytest.fixture()

--- a/tests/test_stow.py
+++ b/tests/test_stow.py
@@ -141,8 +141,6 @@ def test_stow_with_write_only_source(source_a, source_c, dest):
     with pytest.raises(error.InsufficientPermissionsToSubcmdFrom, match=message):
         dploy.stow([source_a, source_c], dest)
 
-    utils.add_read_permission(source_a)  # cleanup
-
 
 def test_stow_with_source_with_no_executue_permissions(source_a, source_c, dest):
     utils.remove_execute_permission(source_a)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -124,4 +124,4 @@ def add_user_permissions(path: os.PathLike) -> None:
 
     mode = stat.S_IMODE(os.lstat(path).st_mode)
     if mode & wanted != wanted:
-        os.lchmod(path, mode | wanted)
+        os.chmod(path, mode | wanted, follow_symlinks=False)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -100,3 +100,28 @@ def remove_execute_permission(path):
     """
     mode = os.stat(path)[stat.ST_MODE]
     os.chmod(path, mode & ~stat.S_IXUSR & ~stat.S_IXGRP & ~stat.S_IXOTH)
+
+
+def restore_tree_permissions(top_directory: os.PathLike) -> None:
+    """Reset users's permissions on a directory tree."""
+    if not os.path.isdir(top_directory):
+        raise NotADirectoryError(f"Invalid directory: {top_directory}")
+
+    add_user_permissions(top_directory)
+    for current_dir, dirs, files in os.walk(top_directory):
+        for file_name in dirs + files:
+            add_user_permissions(os.path.join(current_dir, file_name))
+
+
+def add_user_permissions(path: os.PathLike) -> None:
+    """Restore owner's file/dir permissions."""
+    if not os.path.exists(path) and not os.path.islink(path):
+        raise FileNotFoundError(f"Invalid file or directory: {path}")
+
+    wanted = stat.S_IREAD | stat.S_IWRITE
+    if os.path.isdir(path):
+        wanted |= stat.S_IEXEC
+
+    mode = stat.S_IMODE(os.lstat(path).st_mode)
+    if mode & wanted != wanted:
+        os.lchmod(path, mode | wanted)


### PR DESCRIPTION
Restore missing read, write or execute permissions for temporary source or destination directories, which have been automatically created by pytest. This fixes #6.

* This enables pytest to automatically remove anything remaining in the tmpdir after the fixture is used.
* Before this patch, modern pytest versions would raise PermissionError and leave garbage directory trees.