### PR TITLE
Fix NotImplementedError for chmod on some systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ organized by order of importance.
 
 ### Fixed
 
+- Fixed pytest.
+
 ### Removed
 
 ## [0.1.2] - 2017-10-26

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -123,5 +123,5 @@ def add_user_permissions(path: os.PathLike) -> None:
         wanted |= stat.S_IEXEC
 
     mode = stat.S_IMODE(os.lstat(path).st_mode)
-    if mode & wanted != wanted:
-        os.chmod(path, mode | wanted, follow_symlinks=False)
+    if mode & wanted != wanted and not os.path.islink(path):
+        os.chmod(path, mode | wanted)


### PR DESCRIPTION
I tested the new code on some other flavours of Linux, and it turns out that the system Python on certain Debian based systems (I have access to Devuan GNU/Linux 4) do not support `os.chmod(follow_symlinks=False)`.

The exception is: `NotImplementedError: chmod: follow_symlinks unavailable on this platform`.

I changed the code to avoid this issue.